### PR TITLE
Change network name

### DIFF
--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -42,7 +42,7 @@ module.exports = {
       gas: 6800000,
       skipDryRun: true,
     },
-    development: {
+    develop: {
       host: '127.0.0.1',
       port: 8545,
       network_id: '*',


### PR DESCRIPTION
From PR #47 after we dump truffle to new version, we cannot test contract by using 
```
yarn truffle test
```

or

```
yarn truffle test --network test
```

Because [this PR](https://github.com/trufflesuite/truffle/pull/2004) cannot choose non-existed network if we specific network, so we change name of our development config to develop that make truffle don't use development network for test.

Now use this command to test contracts.
 ```
yarn truffle test
```