### PR TITLE
Upgrade band-solidity 0.0.5

### DIFF
--- a/band-solidity/package.json
+++ b/band-solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "band-solidity",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "Smart Contract library for Band data oracle",
   "files": [
     "/contracts/**/*.sol",

--- a/truffle-box/contracts/GasStation.sol
+++ b/truffle-box/contracts/GasStation.sol
@@ -1,9 +1,8 @@
 pragma solidity 0.5.10;
 
-import {BandLib, usingBand, Oracle} from "band-solidity/contracts/data/BandLib.sol";
+import {BandLib, usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
 
-contract GasStation is usingBand {
-  using BandLib for Oracle;
+contract GasStation is usingBandProtocol {
 
   mapping (string => uint256) public prices;
 

--- a/truffle-box/contracts/GroceryStore.sol
+++ b/truffle-box/contracts/GroceryStore.sol
@@ -1,9 +1,8 @@
 pragma solidity 0.5.10;
 
-import {BandLib, usingBand, Oracle} from "band-solidity/contracts/data/BandLib.sol";
+import {BandLib, usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
 
-contract GroceryStore is usingBand {
-  using BandLib for Oracle;
+contract GroceryStore is usingBandProtocol {
 
   struct Receipt{
     uint256 priceInUSD;
@@ -14,7 +13,7 @@ contract GroceryStore is usingBand {
   mapping(address => Receipt) public lastPay;
 
   function pay(uint256 priceInUSD) public payable {
-    uint256 ethUsd = CRYPTO.queryUint256("ETH/USD");
+    uint256 ethUsd = CRYPTO.querySpotPrice("ETH/USD");
     uint256 price = priceInUSD * 1e36 / ethUsd;
     require(msg.value >= price);
     lastPay[msg.sender] = Receipt(priceInUSD, msg.value, now);

--- a/truffle-box/package.json
+++ b/truffle-box/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "band-solidity": "^0.0.3",
+    "band-solidity": "^0.0.5",
     "solc": "^0.5.11",
     "truffle": "^5.0.32",
     "truffle-hdwallet-provider": "^1.0.16"

--- a/truffle-box/yarn.lock
+++ b/truffle-box/yarn.lock
@@ -297,10 +297,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-band-solidity@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/band-solidity/-/band-solidity-0.0.3.tgz#4767eb5db852a8294c53e1de434b146ce78ddf62"
-  integrity sha512-5V4kXnt0U5SABQUqHBC9lL/9hVpCRfto8yubGr0d2zcsA8yp7A0ZLI043xyviku0L/Xvb4TiDJ9yFsoLz2Ogxg==
+band-solidity@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/band-solidity/-/band-solidity-0.0.5.tgz#870d5392ba0f77d22d31a08b7c9335ab95d917f5"
+  integrity sha512-Obm7tP96ghYSkeKy2DliuBXv+i5p9HR2comhqbqVZjmX9rBmqwAJFV+SmA6npchR2zKronVuM8YMiWpiZP98Dw==
 
 base64-js@^1.0.2:
   version "1.3.1"
@@ -4729,6 +4729,7 @@ websocket@^1.0.28:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
+    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
- Bring `using BandLib for Oracle` to `usingBandProtocol` contract 
- Add `querySpotPrice` and `querySpotPriceWithExpiration` follow docs
- Update truffle box to use new library