### PR TITLE
Remove unnecessary import

### DIFF
--- a/truffle-box/contracts/GasStation.sol
+++ b/truffle-box/contracts/GasStation.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.10;
 
-import {BandLib, usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
+import {usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
 
 contract GasStation is usingBandProtocol {
 

--- a/truffle-box/contracts/GroceryStore.sol
+++ b/truffle-box/contracts/GroceryStore.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.10;
 
-import {BandLib, usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
+import {usingBandProtocol, Oracle} from "band-solidity/contracts/data/BandLib.sol";
 
 contract GroceryStore is usingBandProtocol {
 


### PR DESCRIPTION
We bring using BandLib for Oracle to library, so we don't need BandLib in developed contract.