### PR TITLE
Add Query function to each adapter and add test

### DIFF
--- a/go/adapter/alphavantageforex.go
+++ b/go/adapter/alphavantageforex.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -87,4 +88,19 @@ func (*AlphaVantageForex) QuerySpotPrice(symbol string) (float64, error) {
 		return alphaVantageForexCaches[from+"-"+to].value, nil
 	}
 	return 0, fmt.Errorf("Invalid key")
+}
+
+func (a *AlphaVantageForex) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/alphavantageforex_test.go
+++ b/go/adapter/alphavantageforex_test.go
@@ -43,3 +43,23 @@ func TestAlphaVantageForexUnknownSymbol(t *testing.T) {
 		t.Errorf("Query BTH-USD must contain error. See nothing")
 	}
 }
+
+func TestAlphaVantageForexQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &AlphaVantageForex{}
+	price, err := resolver.Query([]byte("SPOTPX/EUR-USD"))
+	if err != nil {
+		t.Errorf("Query EUR-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(1)) == -1 || priceBig.Cmp(PriceToBigInt(2)) == 1 {
+		t.Errorf("Query EUR-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestAlphaVantageForexQueryInvalidFunction(t *testing.T) {
+	resolver := &AlphaVantageForex{}
+	_, err := resolver.Query([]byte("REALPRICE/EUR-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/EUR-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/alphavantagestock_test.go
+++ b/go/adapter/alphavantagestock_test.go
@@ -31,3 +31,23 @@ func TestAlphaVantageStockUnknownSymbol(t *testing.T) {
 		t.Errorf("Query BTH-USD must contain error. See nothing")
 	}
 }
+
+func TestAlphaVantageStockQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &AlphaVantageStock{}
+	price, err := resolver.Query([]byte("SPOTPX/GOOG"))
+	if err != nil {
+		t.Errorf("Query GOOG error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(500)) == -1 || priceBig.Cmp(PriceToBigInt(2000)) == 1 {
+		t.Errorf("Query GOOG price is way off: %s", priceBig.String())
+	}
+}
+
+func TestAlphaVantageStockQueryInvalidFunction(t *testing.T) {
+	resolver := &AlphaVantageStock{}
+	_, err := resolver.Query([]byte("REALPRICE/GOOG"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/GOOG must contain error. See nothing")
+	}
+}

--- a/go/adapter/bancor.go
+++ b/go/adapter/bancor.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -60,4 +61,19 @@ func (*Bancor) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price0 / price1, nil
+}
+
+func (a *Bancor) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/bancor_test.go
+++ b/go/adapter/bancor_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestSuccess_Bancor(t *testing.T) {
 	resolver := &Bancor{}
-	price, err := resolver.QuerySpotPrice("ETH-USD")
+	price, err := resolver.QuerySpotPrice("DAI-ETH")
 	if err != nil {
-		t.Errorf("Query ETH-USD error: %s", err)
+		t.Errorf("Query DAI-ETH error: %s", err)
 	}
-	if price < 50 || price > 1000 {
-		t.Errorf("Query ETH-USD price is way off: %f", price)
+	if price < 0 || price > 0.01 {
+		t.Errorf("Query DAI-ETH price is way off: %f", price)
 	}
 }
 
@@ -25,8 +25,28 @@ func TestInvalidSymbolFormat_Bancor(t *testing.T) {
 
 func TestUnknownSymbol_Bancor(t *testing.T) {
 	resolver := &Bancor{}
-	_, err := resolver.QuerySpotPrice("ETH-XYZ")
+	_, err := resolver.QuerySpotPrice("DAI-ETG")
 	if err == nil {
-		t.Errorf("Query ETH-XYZ must contain error. See nothing")
+		t.Errorf("Query DAI-ETG must contain error. See nothing")
+	}
+}
+
+func TestQueryToQuerySpotPrice_Bancor(t *testing.T) {
+	resolver := &Bancor{}
+	price, err := resolver.Query([]byte("SPOTPX/DAI-ETH"))
+	if err != nil {
+		t.Errorf("Query DAI-ETH error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(0)) == -1 || priceBig.Cmp(PriceToBigInt(0.01)) == 1 {
+		t.Errorf("Query DAI-ETH price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Bancor(t *testing.T) {
+	resolver := &Bancor{}
+	_, err := resolver.Query([]byte("REALPRICE/DAI-ETH"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/DAI-ETH must contain error. See nothing")
 	}
 }

--- a/go/adapter/bitfinex.go
+++ b/go/adapter/bitfinex.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -43,4 +44,19 @@ func (*Bitfinex) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price.Float(), nil
+}
+
+func (a *Bitfinex) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/bitfinex_test.go
+++ b/go/adapter/bitfinex_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_Bitfinex(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_Bitfinex(t *testing.T) {
+	resolver := &Bitfinex{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Bitfinex(t *testing.T) {
+	resolver := &Bitfinex{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/bitstamp.go
+++ b/go/adapter/bitstamp.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -42,4 +43,19 @@ func (*Bitstamp) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price.Float(), nil
+}
+
+func (a *Bitstamp) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/bitstamp_test.go
+++ b/go/adapter/bitstamp_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_Bitstamp(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_Bitstamp(t *testing.T) {
+	resolver := &CryptoCompare{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Bitstamp(t *testing.T) {
+	resolver := &CryptoCompare{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/bittrex.go
+++ b/go/adapter/bittrex.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -42,4 +43,19 @@ func (*Bittrex) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price.Float(), nil
+}
+
+func (a *Bittrex) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/bittrex_test.go
+++ b/go/adapter/bittrex_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_Bittrex(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_Bittrex(t *testing.T) {
+	resolver := &Bittrex{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Bittrex(t *testing.T) {
+	resolver := &Bittrex{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/coinbase.go
+++ b/go/adapter/coinbase.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -41,4 +42,19 @@ func (*CoinBase) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price.Float(), nil
+}
+
+func (a *CoinBase) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/coinbase_test.go
+++ b/go/adapter/coinbase_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_CoinBase(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_CoinBase(t *testing.T) {
+	resolver := &CoinBase{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_CoinBase(t *testing.T) {
+	resolver := &CoinBase{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/coinmarketcap.go
+++ b/go/adapter/coinmarketcap.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -51,4 +52,19 @@ func (*CoinMarketcap) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return result[0].Float(), nil
+}
+
+func (a *CoinMarketcap) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/coinmarketcap_test.go
+++ b/go/adapter/coinmarketcap_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_CoinMarketcap(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_CoinMarketcap(t *testing.T) {
+	resolver := &CoinMarketcap{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_CoinMarketcap(t *testing.T) {
+	resolver := &CoinMarketcap{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/cryptocompare.go
+++ b/go/adapter/cryptocompare.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type CryptoCompare struct{}
@@ -37,4 +39,19 @@ func (*CryptoCompare) QuerySpotPrice(symbol string) (float64, error) {
 		return 0, fmt.Errorf("spotpx: invalid response from remote %s", result[pairs[1]])
 	}
 	return price, nil
+}
+
+func (a *CryptoCompare) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/cryptocompare_test.go
+++ b/go/adapter/cryptocompare_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &CryptoCompare{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction(t *testing.T) {
+	resolver := &CryptoCompare{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/currencyconverter.go
+++ b/go/adapter/currencyconverter.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var currencyConverterapikey = os.Getenv("CurrencyConverterApikey")
@@ -81,5 +83,19 @@ func (*CurrencyConverter) QuerySpotPrice(symbol string) (float64, error) {
 		return currencyConverterCaches[key], nil
 	}
 	return 0, fmt.Errorf("Invalid key")
+}
 
+func (a *CurrencyConverter) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/currencyconverter_test.go
+++ b/go/adapter/currencyconverter_test.go
@@ -41,3 +41,23 @@ func TestCurrencyConverterUnknownSymbol(t *testing.T) {
 		t.Errorf("Query BTH-USD must contain error. See nothing")
 	}
 }
+
+func TestCurrencyConverterQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &CurrencyConverter{}
+	price, err := resolver.Query([]byte("SPOTPX/EUR-USD"))
+	if err != nil {
+		t.Errorf("Query EUR-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(1)) == -1 || priceBig.Cmp(PriceToBigInt(2)) == 1 {
+		t.Errorf("Query EUR-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestCurrencyConverterQueryInvalidFunction(t *testing.T) {
+	resolver := &CurrencyConverter{}
+	_, err := resolver.Query([]byte("REALPRICE/EUR-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/EUR-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/financialmodelprep.go
+++ b/go/adapter/financialmodelprep.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -36,4 +38,19 @@ func (*FinancialModelPrep) QuerySpotPrice(symbol string) (float64, error) {
 		return 0, fmt.Errorf("Key doesn't existed")
 	}
 	return value.Float(), nil
+}
+
+func (a *FinancialModelPrep) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/financialmodelprep_test.go
+++ b/go/adapter/financialmodelprep_test.go
@@ -31,3 +31,23 @@ func TestFinancialModelPrepUnknownSymbol(t *testing.T) {
 		t.Errorf("Query BTH-USD must contain error. See nothing")
 	}
 }
+
+func TestFinancialModelPrepQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &FinancialModelPrep{}
+	price, err := resolver.Query([]byte("SPOTPX/GOOG"))
+	if err != nil {
+		t.Errorf("Query GOOG error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(500)) == -1 || priceBig.Cmp(PriceToBigInt(2000)) == 1 {
+		t.Errorf("Query GOOG price is way off: %s", priceBig.String())
+	}
+}
+
+func TestFinancialModelPrepQueryInvalidFunction(t *testing.T) {
+	resolver := &FinancialModelPrep{}
+	_, err := resolver.Query([]byte("REALPRICE/GOOG"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/GOOG must contain error. See nothing")
+	}
+}

--- a/go/adapter/freeforexapi.go
+++ b/go/adapter/freeforexapi.go
@@ -24,7 +24,6 @@ func (*FreeForexApi) QuerySpotPrice(symbol string) (float64, error) {
 		return 0, fmt.Errorf("spotpx: symbol %s is not valid", symbol)
 	}
 	key := from + to
-	println(key)
 	client := http.Client{}
 	req, err := http.NewRequest("GET", "https://www.freeforexapi.com/api/live", nil)
 	if err != nil {

--- a/go/adapter/freeforexapi_test.go
+++ b/go/adapter/freeforexapi_test.go
@@ -17,7 +17,7 @@ func TestFreeForexApiSuccess(t *testing.T) {
 	}
 }
 
-func TestCurrencyConverterGoldSuccess(t *testing.T) {
+func TestFreeForexApiGoldSuccess(t *testing.T) {
 	resolver := &FreeForexApi{}
 	price, err := resolver.QuerySpotPrice("XAU")
 	if err != nil {

--- a/go/adapter/gemini.go
+++ b/go/adapter/gemini.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -41,4 +42,19 @@ func (*Gemini) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return price.Float(), nil
+}
+
+func (a *Gemini) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/gemini_test.go
+++ b/go/adapter/gemini_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_Gemini(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_Gemini(t *testing.T) {
+	resolver := &Gemini{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Gemini(t *testing.T) {
+	resolver := &Gemini{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/kraken.go
+++ b/go/adapter/kraken.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -69,4 +70,19 @@ func (*Kraken) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return lastElement[0].Float(), nil
+}
+
+func (a *Kraken) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/kraken_test.go
+++ b/go/adapter/kraken_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_Kraken(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_Kraken(t *testing.T) {
+	resolver := &Kraken{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Kraken(t *testing.T) {
+	resolver := &Kraken{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/kyber.go
+++ b/go/adapter/kyber.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -106,4 +107,19 @@ func (*Kyber) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return 1.0, nil
+}
+
+func (a *Kyber) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/kyber_test.go
+++ b/go/adapter/kyber_test.go
@@ -6,12 +6,12 @@ import (
 
 func TestSuccess_Kyber(t *testing.T) {
 	resolver := &Kyber{}
-	price, err := resolver.QuerySpotPrice("ETH-DAI")
+	price, err := resolver.QuerySpotPrice("DAI-ETH")
 	if err != nil {
-		t.Errorf("Query ETH-USD error: %s", err)
+		t.Errorf("Query DAI-ETH error: %s", err)
 	}
-	if price < 50 || price > 1000 {
-		t.Errorf("Query ETH-USD price is way off: %f", price)
+	if price < 0 || price > 0.01 {
+		t.Errorf("Query DAI-ETH price is way off: %f", price)
 	}
 }
 
@@ -25,8 +25,28 @@ func TestInvalidSymbolFormat_Kyber(t *testing.T) {
 
 func TestUnknownSymbol_Kyber(t *testing.T) {
 	resolver := &Kyber{}
-	_, err := resolver.QuerySpotPrice("ETH-XYZ")
+	_, err := resolver.QuerySpotPrice("DAI-ETG")
 	if err == nil {
-		t.Errorf("Query ETH-XYZ must contain error. See nothing")
+		t.Errorf("Query ETH-ETG must contain error. See nothing")
+	}
+}
+
+func TestQueryToQuerySpotPrice_Kyber(t *testing.T) {
+	resolver := &Kyber{}
+	price, err := resolver.Query([]byte("SPOTPX/DAI-ETH"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(0)) == -1 || priceBig.Cmp(PriceToBigInt(0.01)) == 1 {
+		t.Errorf("Query DAI-ETH price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Kyber(t *testing.T) {
+	resolver := &Kyber{}
+	_, err := resolver.Query([]byte("REALPRICE/DAI-ETH"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/DAI-ETH must contain error. See nothing")
 	}
 }

--- a/go/adapter/openmarketcap.go
+++ b/go/adapter/openmarketcap.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -59,4 +60,19 @@ func (*OpenMarketCap) QuerySpotPrice(symbol string) (float64, error) {
 	}
 
 	return prices[pairs[0]] / prices[pairs[1]], nil
+}
+
+func (a *OpenMarketCap) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/openmarketcap_test.go
+++ b/go/adapter/openmarketcap_test.go
@@ -30,3 +30,23 @@ func TestUnknownSymbol_OpenMarketCap(t *testing.T) {
 		t.Errorf("Query ETH-XYZ must contain error. See nothing")
 	}
 }
+
+func TestQueryToQuerySpotPrice_OpenMarketCap(t *testing.T) {
+	resolver := &OpenMarketCap{}
+	price, err := resolver.Query([]byte("SPOTPX/ETH-USD"))
+	if err != nil {
+		t.Errorf("Query ETH-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(50)) == -1 || priceBig.Cmp(PriceToBigInt(1000)) == 1 {
+		t.Errorf("Query ETH-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_OpenMarketCap(t *testing.T) {
+	resolver := &OpenMarketCap{}
+	_, err := resolver.Query([]byte("REALPRICE/ETH-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/ETH-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/ratesapi.go
+++ b/go/adapter/ratesapi.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -42,4 +43,19 @@ func (*Ratesapi) QuerySpotPrice(symbol string) (float64, error) {
 		return 0, fmt.Errorf("Key doesn't existed")
 	}
 	return value.Float(), nil
+}
+
+func (a *Ratesapi) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/ratesapi_test.go
+++ b/go/adapter/ratesapi_test.go
@@ -31,3 +31,23 @@ func TestRatesapiUnknownSymbol(t *testing.T) {
 		t.Errorf("Query BTH-USD must contain error. See nothing")
 	}
 }
+
+func TestRatesapiQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &Ratesapi{}
+	price, err := resolver.Query([]byte("SPOTPX/EUR-USD"))
+	if err != nil {
+		t.Errorf("Query EUR-USD error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(1)) == -1 || priceBig.Cmp(PriceToBigInt(2)) == 1 {
+		t.Errorf("Query EUR-USD price is way off: %s", priceBig.String())
+	}
+}
+
+func TestRatesapiQueryInvalidFunction(t *testing.T) {
+	resolver := &Ratesapi{}
+	_, err := resolver.Query([]byte("REALPRICE/EUR-USD"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/EUR-USD must contain error. See nothing")
+	}
+}

--- a/go/adapter/types.go
+++ b/go/adapter/types.go
@@ -12,6 +12,20 @@ type Adapter interface {
 
 type MockAdapter struct{}
 
+func PriceToBigInt(price float64) *big.Int {
+	bigval := new(big.Float)
+	bigval.SetFloat64(price)
+
+	multiplier := new(big.Float)
+	multiplier.SetInt(big.NewInt(1000000000000000000))
+	bigval.Mul(bigval, multiplier)
+
+	result := new(big.Int)
+	bigval.Int(result)
+
+	return result
+}
+
 func (*MockAdapter) Query([]byte) (common.Hash, error) {
 	return common.BigToHash(big.NewInt(100)), nil
 }

--- a/go/adapter/types_test.go
+++ b/go/adapter/types_test.go
@@ -1,0 +1,19 @@
+package adapter
+
+import (
+	"testing"
+)
+
+func TestPriceToBigInt(t *testing.T) {
+	price := 123.79
+	bigInt := PriceToBigInt(price)
+	if bigInt.String() != "123790000000000000000" {
+		t.Errorf("Convert incorrect")
+	}
+
+	price = 0.0094
+	bigInt = PriceToBigInt(price)
+	if bigInt.String() != "9400000000000000" {
+		t.Errorf("Convert incorrect")
+	}
+}

--- a/go/adapter/uniswap_test.go
+++ b/go/adapter/uniswap_test.go
@@ -8,10 +8,10 @@ func TestSuccess_Uniswap(t *testing.T) {
 	resolver := &Uniswap{}
 	price, err := resolver.QuerySpotPrice("DAI-ETH")
 	if err != nil {
-		t.Errorf("Query ETH-USD error: %s", err)
+		t.Errorf("Query DAI-ETH error: %s", err)
 	}
-	if price < 50 || price > 1000 {
-		t.Errorf("Query ETH-USD price is way off: %f", price)
+	if price < 0 || price > 0.01 {
+		t.Errorf("Query DAI-ETH price is way off: %f", price)
 	}
 }
 
@@ -25,8 +25,28 @@ func TestInvalidSymbolFormat_Uniswap(t *testing.T) {
 
 func TestUnknownSymbol_Uniswap(t *testing.T) {
 	resolver := &Uniswap{}
-	_, err := resolver.QuerySpotPrice("ETH-XYZ")
+	_, err := resolver.QuerySpotPrice("DAI-ETG")
 	if err == nil {
-		t.Errorf("Query ETH-XYZ must contain error. See nothing")
+		t.Errorf("Query DAI-ETG must contain error. See nothing")
+	}
+}
+
+func TestQueryToQuerySpotPrice_Uniswap(t *testing.T) {
+	resolver := &Uniswap{}
+	price, err := resolver.Query([]byte("SPOTPX/DAI-ETH"))
+	if err != nil {
+		t.Errorf("Query DAI-ETH error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(0)) == -1 || priceBig.Cmp(PriceToBigInt(0.01)) == 1 {
+		t.Errorf("Query DAI-ETH price is way off: %s", priceBig.String())
+	}
+}
+
+func TestQueryInvalidFunction_Uniswap(t *testing.T) {
+	resolver := &Uniswap{}
+	_, err := resolver.Query([]byte("REALPRICE/DAI-ETH"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/DAI-ETH must contain error. See nothing")
 	}
 }

--- a/go/adapter/worldtradingdata.go
+++ b/go/adapter/worldtradingdata.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
 
@@ -49,4 +50,19 @@ func (*WorldTradingData) QuerySpotPrice(symbol string) (float64, error) {
 		return 0, fmt.Errorf("Cannot find price for %s stock symbol", symbol)
 	}
 	return value[1].Float(), nil
+}
+
+func (a *WorldTradingData) Query(key []byte) (common.Hash, error) {
+	keys := strings.Split(string(key), "/")
+	if len(keys) != 2 {
+		return common.HexToHash("0"), fmt.Errorf("Invalid key format")
+	}
+	if keys[0] == "SPOTPX" {
+		value, err := a.QuerySpotPrice(keys[1])
+		if err != nil {
+			return common.HexToHash("0"), err
+		}
+		return common.BigToHash(PriceToBigInt(value)), nil
+	}
+	return common.HexToHash("0"), fmt.Errorf("Doesn't supported %s query", keys[0])
 }

--- a/go/adapter/worldtradingdata_test.go
+++ b/go/adapter/worldtradingdata_test.go
@@ -31,3 +31,23 @@ func TestWorldTradingDataUnknownSymbol(t *testing.T) {
 		t.Errorf("Query FD must contain error. See nothing")
 	}
 }
+
+func TestWorldTradingDataQueryToQuerySpotPrice(t *testing.T) {
+	resolver := &WorldTradingData{}
+	price, err := resolver.Query([]byte("SPOTPX/GOOG"))
+	if err != nil {
+		t.Errorf("Query GOOG error: %s", err)
+	}
+	priceBig := price.Big()
+	if priceBig.Cmp(PriceToBigInt(500)) == -1 || priceBig.Cmp(PriceToBigInt(2000)) == 1 {
+		t.Errorf("Query GOOG price is way off: %s", priceBig.String())
+	}
+}
+
+func TestWorldTradingDataQueryInvalidFunction(t *testing.T) {
+	resolver := &WorldTradingData{}
+	_, err := resolver.Query([]byte("REALPRICE/GOOG"))
+	if err == nil {
+		t.Errorf("Query REALPRICE/GOOG must contain error. See nothing")
+	}
+}


### PR DESCRIPTION
- Add `Query` function to return bytes32 as output
- Fix test for bancor, uniswap, and kyber