### PR TITLE
fix whitepaper version on the websiteto 3.1 to 3.0

### DIFF
--- a/web/src/pages/Landing/Landing.js
+++ b/web/src/pages/Landing/Landing.js
@@ -160,7 +160,7 @@ export default () => {
                   <Flex mx={['0px', '10px']} my={['10px', '0px']} />
                   <AbsoluteLink href="/whitepaper-3.0.0.pdf">
                     <OutlineButton isMobile={_isMobile}>
-                      Whitepaper v3.1
+                      Whitepaper v3.0
                     </OutlineButton>
                   </AbsoluteLink>
                 </Flex>


### PR DESCRIPTION
Fixes #113 

- fix whitepaper version on the websiteto 3.1 to 3.0

![a](https://user-images.githubusercontent.com/17776802/63662425-935a0080-c7e8-11e9-85a4-0fa5283416bd.png)
