### PR TITLE
Move reuse struct to new package

### DIFF
--- a/go/reqmsg/msg.go
+++ b/go/reqmsg/msg.go
@@ -1,0 +1,42 @@
+package reqmsg
+
+import (
+	"encoding/hex"
+	"strings"
+
+	"github.com/bandprotocol/band/go/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type DataRequest struct {
+	Dataset common.Address `json:"dataset"`
+	Key     string         `json:"key"`
+}
+
+func (input *DataRequest) NormalizeKey() {
+	if strings.HasPrefix(input.Key, "0x") {
+		decoded, err := hex.DecodeString(input.Key[2:])
+		if err == nil {
+			input.Key = string(decoded)
+		}
+	}
+}
+
+type DataResponse struct {
+	Provider  common.Address `json:"provider"`
+	Value     common.Hash    `json:"value"`
+	Timestamp uint64         `json:"timestamp"`
+	Sig       eth.Signature  `json:"signature"`
+}
+type SignRequest struct {
+	DataRequest
+	Datapoints []DataResponse `json:"datapoints"`
+}
+
+type SignResponse struct {
+	Provider  common.Address `json:"provider"`
+	Value     common.Hash    `json:"value"`
+	Timestamp uint64         `json:"timestamp"`
+	Sig       eth.Signature  `json:"signature"`
+	Status    string         `json:"status"`
+}


### PR DESCRIPTION
Due to coordinator and node use same request message, so we separate those message to new package and reuse code from that package instead copy-paste struct.