### PR TITLE
Implement web request driver

### DIFF
--- a/go/driver/types.go
+++ b/go/driver/types.go
@@ -95,6 +95,8 @@ func FromConfigIndividual(config *viper.Viper) Driver {
 		adpt = &IdleDriver{}
 	case "DelegateDriver":
 		adpt = &DelegateDriver{}
+	case "WebRequest":
+		adpt = &WebRequest{}
 	case "AlphaVantageStock":
 		adpt = &AlphaVantageStock{}
 	case "WorldTradingData":

--- a/go/driver/webrequest.go
+++ b/go/driver/webrequest.go
@@ -1,0 +1,176 @@
+package driver
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/btcsuite/btcutil/base58"
+	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/spf13/viper"
+	"github.com/tidwall/gjson"
+)
+
+type WebRequest struct {
+	store *shell.Shell
+}
+
+func (w *WebRequest) Configure(*viper.Viper) {
+	w.store = shell.NewShell("https://ipfs.bandprotocol.com")
+}
+
+func GetMultiplierValue(price float64, m int64) *big.Int {
+	bigval := new(big.Float)
+	bigval.SetFloat64(price)
+
+	multiplier := new(big.Float)
+	multiplier.SetInt(big.NewInt(m))
+	bigval.Mul(bigval, multiplier)
+
+	result := new(big.Int)
+	bigval.Int(result)
+
+	return result
+}
+
+func replaceString(
+	original string,
+	regex *regexp.Regexp,
+	params []interface{},
+	pt []string,
+) string {
+	paramURLIndex := regex.FindAllStringIndex(original, -1)
+	var output strings.Builder
+	lastIndex := 0
+	for _, match := range paramURLIndex {
+		st := match[0]
+		ed := match[1]
+		output.WriteString(original[lastIndex:st])
+		index, _ := strconv.Atoi(original[st+1 : ed-1])
+		if pt[index] == "string" {
+			output.WriteString(params[index].(string))
+		}
+		lastIndex = ed
+	}
+	output.WriteString(original[lastIndex:])
+	return output.String()
+}
+
+func (w *WebRequest) Query(_key []byte) Answer {
+	paramRegex, _ := regexp.Compile(`\{\d*\}`)
+	key := hex.EncodeToString(_key)
+	params := make([]interface{}, 0)
+	paramsType := make([]string, 0)
+	var answer gjson.Result
+
+	// Minimum ipfs (hex) hash length is 2(0x) + 4 (1220) + 64(32 byte)
+	if len(key) < 68 {
+		return NotFoundAnswer
+	}
+	hexKey := string(key)
+	ipfsHash, err := hex.DecodeString(hexKey[:68])
+	if err != nil {
+		return NotFoundAnswer
+	}
+	read, err := w.store.Cat(base58.Encode(ipfsHash))
+	if err != nil {
+		return NotFoundAnswer
+	}
+	defer read.Close()
+
+	rawBytes, err := ioutil.ReadAll(read)
+	if err != nil {
+		return NotFoundAnswer
+	}
+
+	results := gjson.GetManyBytes(rawBytes, "meta", "request", "response")
+	meta := results[0].Map()
+	request := results[1].Map()
+	response := results[2].Map()
+
+	rawParamType := meta["variables"].Array()
+	parameterBytes, err := hex.DecodeString((hexKey[68:]))
+	if err != nil {
+		return NotFoundAnswer
+	}
+
+	for _, pt := range rawParamType {
+		word := make([]byte, 0)
+		for parameterBytes[0] != 0 {
+			word = append(word, parameterBytes[0])
+			parameterBytes = parameterBytes[1:]
+			if len(parameterBytes) == 0 {
+				return NotFoundAnswer
+			}
+		}
+		parameterBytes = parameterBytes[1:]
+		paramsType = append(paramsType, pt.String())
+		if pt.String() == "string" {
+			params = append(params, string(word))
+		}
+	}
+
+	// Must use all parameter
+	if len(parameterBytes) != 0 {
+		return NotFoundAnswer
+	}
+
+	url := replaceString(request["url"].String(), paramRegex, params, paramsType)
+	method := request["method"].String()
+	if method == "GET" {
+		client := &http.Client{}
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return NotFoundAnswer
+		}
+		if reqParams, ok := request["params"]; ok {
+			q := req.URL.Query()
+			for name, arg := range reqParams.Map() {
+				q.Add(name, replaceString(arg.String(), paramRegex, params, paramsType))
+			}
+			req.URL.RawQuery = q.Encode()
+		}
+
+		req.Header.Add("Accept", "application/json")
+		res, err := client.Do(req)
+		if err != nil {
+			return NotFoundAnswer
+		}
+		defer res.Body.Close()
+
+		var responsePath strings.Builder
+		body, err := ioutil.ReadAll(res.Body)
+		for i, path := range response["path"].Array() {
+
+			responsePath.WriteString(replaceString(path.String(), paramRegex, params, paramsType))
+
+			if i != len(response["path"].Array())-1 {
+				responsePath.WriteString(".")
+			}
+		}
+		answer = gjson.GetBytes(body, responsePath.String())
+	} else {
+		return NotFoundAnswer
+	}
+
+	if response["type"].String() == "uint256" {
+		var mutilplier int64
+		if m, ok := response["multiplier"]; ok {
+			mutilplier = m.Int()
+		} else {
+			mutilplier = 1
+		}
+		return Answer{
+			Option: OK,
+			Value:  common.BigToHash(GetMultiplierValue(answer.Float(), mutilplier)),
+		}
+	}
+	return NotFoundAnswer
+}

--- a/go/driver/webrequest_test.go
+++ b/go/driver/webrequest_test.go
@@ -1,0 +1,82 @@
+package driver
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestTwitterFollower(t *testing.T) {
+	web := &WebRequest{}
+	web.Configure(viper.New())
+	decodeKey, _ := hex.DecodeString(
+		"1220a9ab69e5da8ac5e378796cef1d9cda4f38d9f42e77ef5aebfceeaf33334de0ed62616e6470726f746f636f6c00",
+	)
+	ans := web.Query(decodeKey)
+	if ans.Option != OK {
+		t.Errorf("Option should be OK but got %s", ans.Option)
+	}
+	value := ans.Value.Big().Uint64()
+	if value < 0 || value > 1000000000 {
+		t.Errorf("Query twitter followers is way off: %d", value)
+	}
+}
+
+func TestBinanceBalance(t *testing.T) {
+	web := &WebRequest{}
+	web.Configure(viper.New())
+	decodeKey, _ := hex.DecodeString(
+		"1220784c2aa37a5f5ea6465b6c02be1779684681ec1c625ca469e6ba167157f516f7626e62316a78666832673835713376307464713536666e6576783678637874636e6874736d637536346d00",
+	)
+	ans := web.Query(decodeKey)
+	if ans.Option != OK {
+		t.Errorf("Option should be OK but got %s", ans.Option)
+	}
+	value := ans.Value.Big()
+	if value.Cmp(GetMultiplierValue(1, 1000000000000000000)) == -1 ||
+		value.Cmp(GetMultiplierValue(100000000, 1000000000000000000)) == 1 {
+		t.Errorf("Query twitter followers is way off: %d", value)
+	}
+}
+
+func TestGasStation(t *testing.T) {
+	web := &WebRequest{}
+	web.Configure(viper.New())
+	decodeKey, _ := hex.DecodeString(
+		"1220a39f6304fff1d0e09d093fbb52b733a1dc866d451cb5931d422245396e5596dd6661737400",
+	)
+	ans := web.Query(decodeKey)
+	if ans.Option != OK {
+		t.Errorf("Option should be OK but got %s", ans.Option)
+	}
+	value := ans.Value.Big()
+	if value.Cmp(GetMultiplierValue(1, 100000000)) == -1 ||
+		value.Cmp(GetMultiplierValue(1000, 100000000)) == 1 {
+		t.Errorf("Query twitter followers is way off: %d", value)
+	}
+}
+
+func TestTwitterFollowerExceedParams(t *testing.T) {
+	web := &WebRequest{}
+	web.Configure(viper.New())
+	decodeKey, _ := hex.DecodeString(
+		"1220a9ab69e5da8ac5e378796cef1d9cda4f38d9f42e77ef5aebfceeaf33334de0ed62616e6470726f746f636f6c00a2",
+	)
+	ans := web.Query(decodeKey)
+	if ans.Option != NotFound {
+		t.Errorf("Option should be NotFound but got %s", ans.Option)
+	}
+}
+
+func TestQueryTooShort(t *testing.T) {
+	web := &WebRequest{}
+	web.Configure(viper.New())
+	decodeKey, _ := hex.DecodeString(
+		"1220a9ab69e5da8ac5e378796cef1d9cda4f",
+	)
+	ans := web.Query(decodeKey)
+	if ans.Option != NotFound {
+		t.Errorf("Option should be NotFound but got %s", ans.Option)
+	}
+}

--- a/go/eth/provider.go
+++ b/go/eth/provider.go
@@ -67,6 +67,7 @@ func IsValidDataset(dataset common.Address) bool {
 		common.HexToAddress("0xa24dF0420dE1f3b8d740A52AAEB9d55d6D64478e"),
 		common.HexToAddress("0xF904Db9817E4303c77e1Df49722509a0d7266934"),
 		common.HexToAddress("0x7b09c1255b27fCcFf18ecC0B357ac5fFf5f5cb31"),
+		common.HexToAddress("0x7f525974d824a6C4Efd54b9E7CB268eBEFc94aD8"),
 	}
 	for _, validDataset := range validDatesets {
 		if dataset == validDataset {


### PR DESCRIPTION
- Receive key in the same format in blockchain and send request to get data correctly.
- Now only support Get request
- Custom parameters should be `string` type
- Return result supported uint256 with multiplier.
- Test both node and coordinator send value to dataset contract.